### PR TITLE
Exception throwing error with db.get()

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -94,7 +94,9 @@ module CouchRest
     def get(id, params = {})
       slug = escape_docid(id)
       url = CouchRest.paramify_url("#{@root}/#{slug}", params)
-      result = CouchRest.get(url)
+      result = begin; CouchRest.get(url)
+               rescue RestClient::ResourceNotFound; nil
+               end
       return result unless result.is_a?(Hash)
       doc = if /^_design/ =~ result["_id"]
         Design.new(result)


### PR DESCRIPTION
Attempting to get a doc whose id doesn't exist throws an exception. I think the method should just return nil. Here's a quick fix.