### PR TITLE
Fixes when URL contains $ or @ signs

### DIFF
--- a/lib/couchrest/helper/streamer.rb
+++ b/lib/couchrest/helper/streamer.rb
@@ -18,7 +18,7 @@ module CouchRest
       url = CouchRest.paramify_url urlst, params
       # puts "stream #{url}"
       first = nil
-      IO.popen("curl --silent \"#{url}\"") do |view|
+      IO.popen("curl --silent '#{url}'") do |view|
         first = view.gets # discard header
         while line = view.gets 
           row = parse_line(line)


### PR DESCRIPTION
If your password contains shell meta characters, streamer hangs. Using single quotes instead of double quotes to fix the problem.
