### PR TITLE
One more change to make db.documents streamable

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -35,13 +35,17 @@ module CouchRest
     end
     
     # Query the <tt>_all_docs</tt> view. Accepts all the same arguments as view.
-    def documents(params = {})
+    def documents(params = {}, &block)
       keys = params.delete(:keys)
       url = CouchRest.paramify_url "#{@root}/_all_docs", params
       if keys
         CouchRest.post(url, {:keys => keys})
       else
-        CouchRest.get url
+        if block_given?
+          @streamer.view("_all_docs", params, &block)
+        else
+          CouchRest.get url
+        end
       end
     end
 

--- a/lib/couchrest/helper/streamer.rb
+++ b/lib/couchrest/helper/streamer.rb
@@ -18,7 +18,7 @@ module CouchRest
       url = CouchRest.paramify_url urlst, params
       # puts "stream #{url}"
       first = nil
-      IO.popen("curl --silent \"#{url}\"") do |view|
+      IO.popen("curl --silent '#{url}'") do |view|
         first = view.gets # discard header
         while line = view.gets 
           row = parse_line(line)


### PR DESCRIPTION
Makes it more memory friendly to walk the _all_docs of a db containing large number of documents (dump/restore for example)