### PR TITLE
word_count example: db.save should be db.save_doc

### DIFF
--- a/examples/word_count/word_count.rb
+++ b/examples/word_count/word_count.rb
@@ -28,7 +28,7 @@ books.keys.each do |book|
     while line = file.gets
       lines << line
       if lines.length > 10
-        db.save({
+        db.save_doc({
           :title => title,
           :chunk => chunk, 
           :text => lines.join('')

--- a/examples/word_count/word_count_query.rb
+++ b/examples/word_count/word_count_query.rb
@@ -6,7 +6,7 @@ db = couch.database('word-count-example')
 
 puts "Now that we've parsed all those books into CouchDB, the queries we can run are incredibly flexible."
 puts "\nThe simplest query we can run is the total word count for all words in all documents:"
-puts "this will take a few minutes the first time. if it times out, just rerun this script in a few few minutes."
+puts "this will take a few minutes the first time. if it times out, just rerun this script in a few minutes."
 puts db.view('word_count/words').inspect
 
 puts "\nWe can also narrow the query down to just one word, across all documents. Here is the count for 'flight' in all three books:"

--- a/examples/word_count/word_count_views.rb
+++ b/examples/word_count/word_count_views.rb
@@ -18,7 +18,7 @@ word_count = {
 
 db.delete db.get("_design/word_count") rescue nil
 
-db.save({
+db.save_doc({
   "_id" => "_design/word_count",
   :views => {
     :words => word_count


### PR DESCRIPTION
CouchRest::Database doesn't have a #save method, I think this should be #save_doc. 