### PR TITLE
Do not require the document to be explicitly returned at the end of the block when using #update_doc

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -266,9 +266,9 @@ module CouchRest
 
       until resp['ok'] or update_limit <= 0
         doc = self.get(doc_id, params)  # grab the doc
-        new_doc = yield doc # give it to the caller to be updated
+        yield doc# give it to the caller to be updated
         begin
-          resp = self.save_doc new_doc # try to PUT the updated doc into the db
+          resp = self.save_doc doc # try to PUT the updated doc into the db
         rescue RestClient::RequestFailed => e
           if e.http_code == 409 # Update collision
             update_limit -= 1
@@ -280,7 +280,7 @@ module CouchRest
       end
 
       raise last_fail unless resp['ok']
-      new_doc
+      doc
     end
     
     # Compact the database, removing old document revisions and optimizing space use.

--- a/spec/couchrest/database_spec.rb
+++ b/spec/couchrest/database_spec.rb
@@ -565,6 +565,11 @@ describe CouchRest::Database do
       end
       @db.get(@id)['upvotes'].should == 11
     end
+    it "should work if I do not explicitly return the hash" do
+      @db.update_doc @id do |doc|
+        doc['upvotes'] += 1
+      end
+    end
     it "should fail if update_limit is reached" do
       lambda do
         @db.update_doc @id do |doc|


### PR DESCRIPTION
It feels more natural to just update the given document and let that document be the updated hash.
