### PR TITLE
Support multiple JSON gems with multi_json

### DIFF
--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<rest-client>, ["~> 1.6.1"])
   s.add_dependency(%q<mime-types>, ["~> 1.15"])
-  s.add_dependency(%q<json>, ["~> 1.5.1"])
+  s.add_dependency(%q<multi_json>, ["~> 0.0.5"])
+  s.add_development_dependency(%q<json>, ["~> 1.5.1"])
   s.add_development_dependency(%q<rspec>, "~> 1.3.0")
 
 end

--- a/lib/couchrest.rb
+++ b/lib/couchrest.rb
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 require 'rest_client'
-require 'json'
+require 'multi_json'
 
 # Not sure why this is required, so removed until a reason is found!
 $:.unshift File.dirname(__FILE__) unless
@@ -111,7 +111,7 @@ module CouchRest
     def paramify_url url, params = {}
       if params && !params.empty?
         query = params.collect do |k,v|
-          v = v.to_json if %w{key startkey endkey}.include?(k.to_s)
+          v = MultiJson.encode(v) if %w{key startkey endkey}.include?(k.to_s)
           "#{k}=#{CGI.escape(v.to_s)}"
         end.join("&")
         url = "#{url}?#{query}"

--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -313,7 +313,7 @@ module CouchRest
     def put_attachment(doc, name, file, options = {})
       docid = escape_docid(doc['_id'])
       uri = url_for_attachment(doc, name)
-      JSON.parse(RestClient.put(uri, file, CouchRest.default_headers.merge(options)))
+      MultiJson.decode(RestClient.put(uri, file, CouchRest.default_headers.merge(options)))
     end
 
     # DELETE an attachment directly from CouchDB

--- a/lib/couchrest/helper/streamer.rb
+++ b/lib/couchrest/helper/streamer.rb
@@ -16,7 +16,7 @@ module CouchRest
     end
 
     def post(url, params = {}, &block)
-      open_pipe("curl #{default_curl_opts} -d \"#{escape_quotes(params.to_json)}\" \"#{url}\"", &block)
+      open_pipe("curl #{default_curl_opts} -d \"#{escape_quotes(MultiJson.encode(params))}\" \"#{url}\"", &block)
     end
 
     protected
@@ -40,7 +40,7 @@ module CouchRest
     def parse_line line
       return nil unless line
       if /(\{.*\}),?/.match(line.chomp)
-        JSON.parse($1)
+        MultiJson.decode($1)
       end
     end
 
@@ -49,7 +49,7 @@ module CouchRest
       parts = first.split(',')
       parts.pop
       line = parts.join(',')
-      JSON.parse("#{line}}")
+      MultiJson.decode("#{line}}")
     rescue
       nil
     end

--- a/lib/couchrest/middlewares/logger.rb
+++ b/lib/couchrest/middlewares/logger.rb
@@ -68,7 +68,7 @@ module RestClient
   
   def self.post(uri, payload, headers=nil)
     start_query = Time.now
-    log = {:method => :post, :uri => uri, :payload =>  (payload ? (JSON.load(payload) rescue 'parsing error') : nil), :headers => headers}
+    log = {:method => :post, :uri => uri, :payload =>  (payload ? (MultiJson.decode(payload) rescue 'parsing error') : nil), :headers => headers}
     response = super(uri, payload, headers=nil)
     end_query = Time.now
     log[:duration] = (end_query - start_query)
@@ -78,7 +78,7 @@ module RestClient
    
   def self.put(uri, payload, headers=nil)
     start_query = Time.now
-    log = {:method => :put, :uri => uri, :payload => (payload ? (JSON.load(payload) rescue 'parsing error') : nil), :headers => headers}
+    log = {:method => :put, :uri => uri, :payload => (payload ? (MultiJson.decode(payload) rescue 'parsing error') : nil), :headers => headers}
     response = super(uri, payload, headers=nil)
     end_query = Time.now
     log[:duration] = (end_query - start_query)

--- a/lib/couchrest/rest_api.rb
+++ b/lib/couchrest/rest_api.rb
@@ -8,9 +8,9 @@ module RestAPI
   end
 
   def put(uri, doc = nil)
-    payload = doc.to_json if doc
+    payload = MultiJson.encode(doc) if doc
     begin
-      JSON.parse(RestClient.put(uri, payload, default_headers))
+      MultiJson.decode(RestClient.put(uri, payload, default_headers))
     rescue Exception => e
       if $DEBUG
         raise "Error while sending a PUT request #{uri}\npayload: #{payload.inspect}\n#{e}"
@@ -22,7 +22,7 @@ module RestAPI
 
   def get(uri)
     begin
-      JSON.parse(RestClient.get(uri, default_headers), :max_nesting => false)
+      MultiJson.decode(RestClient.get(uri, default_headers), :max_nesting => false)
     rescue => e
       if $DEBUG
         raise "Error while sending a GET request #{uri}\n: #{e}"
@@ -33,9 +33,9 @@ module RestAPI
   end
 
   def post(uri, doc = nil)
-    payload = doc.to_json if doc
+    payload = MultiJson.encode(doc) if doc
     begin
-      JSON.parse(RestClient.post(uri, payload, default_headers))
+      MultiJson.decode(RestClient.post(uri, payload, default_headers))
     rescue Exception => e
       if $DEBUG
         raise "Error while sending a POST request #{uri}\npayload: #{payload.inspect}\n#{e}"
@@ -46,14 +46,14 @@ module RestAPI
   end
 
   def delete(uri)
-    JSON.parse(RestClient.delete(uri, default_headers))
+    MultiJson.decode(RestClient.delete(uri, default_headers))
   end
 
-  def copy(uri, destination) 
-    JSON.parse(RestClient::Request.execute( :method => :copy,
+  def copy(uri, destination)
+    MultiJson.decode(RestClient::Request.execute( :method => :copy,
                                             :url => uri,
                                             :headers => default_headers.merge('Destination' => destination)
                                           ).to_s)
-  end 
+  end
 
 end

--- a/spec/couchrest/database_spec.rb
+++ b/spec/couchrest/database_spec.rb
@@ -257,7 +257,7 @@ describe CouchRest::Database do
           ])
       rescue RestClient::RequestFailed => e
         # soon CouchDB will provide _which_ docs conflicted
-        JSON.parse(e.response.body)['error'].should == 'conflict'
+        MultiJson.decode(e.response.body)['error'].should == 'conflict'
       end
     end
   end


### PR DESCRIPTION
Not sure if this is of interest to anyone else, but I'd like to remove the json gem dependency and have my choice of JSON library to use. This commit uses [multi_json](https://github.com/intridea/multi_json) for encoding/decoding, which is a library that allows you to use yajl-ruby, json, json_pure, or activesupport.
