### PR TITLE
Fix pager spec

### DIFF
--- a/spec/couchrest/helpers/pager_spec.rb
+++ b/spec/couchrest/helpers/pager_spec.rb
@@ -7,6 +7,11 @@ describe CouchRest::Pager do
     @db.delete! rescue nil
     @db = @cr.create_db(TESTDB) rescue nil
     @pager = CouchRest::Pager.new(@db)
+    @docs = []
+    100.times do |i|
+      @docs << ({:number => (i % 10)})
+    end
+    @db.bulk_save(@docs)
   end
   
   after(:all) do
@@ -21,13 +26,6 @@ describe CouchRest::Pager do
   end
   
   describe "paging all docs" do
-    before(:all) do
-      @docs = []
-      100.times do |i|
-        @docs << ({:number => (i % 10)})
-      end
-      @db.bulk_save(@docs)
-    end
     it "should yield total_docs / limit times" do
       n = 0
       @pager.all_docs(10) do |doc|
@@ -55,11 +53,6 @@ describe CouchRest::Pager do
   
   describe "Pager with a view and docs" do
     before(:all) do
-      @docs = []
-      100.times do |i|
-        @docs << ({:number => (i % 10)})
-      end
-      @db.bulk_save(@docs)
       @db.save_doc({
         '_id' => '_design/magic',
         'views' => {


### PR DESCRIPTION
A set of 100 docs were being created in 2 sets of before(:all) blocks. This was causing the examples in the second describe block to fail, since twice as many documents were being created than were expected. Not sure if this was caused by a change in before(:all) behavior between RSpec 1 and 2. I have moved the document creation to the topmost before(:all) block, so that it only gets run once for all examples.
