### PR TITLE
Use multi_json ~> 1.0.0

### DIFF
--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<rest-client>, ["~> 1.6.1"])
   s.add_dependency(%q<mime-types>, ["~> 1.15"])
-  s.add_dependency(%q<multi_json>, ["~> 0.0.5"])
+  s.add_dependency(%q<multi_json>, ["~> 1.0.0"])
   s.add_development_dependency(%q<json>, ["~> 1.5.1"])
   s.add_development_dependency(%q<rspec>, "~> 2.6.0")
 end


### PR DESCRIPTION
Sorry, I just got my multi_json commit merged, and now I'm updating the version! Since I made the first commit, the 1.0 version of multi_json was released, so I think it makes sense to use the latest version. Also, multi_json ~> 1.0 is a Rails 3.1 dependency.
