### PR TITLE
Database#replicate is sending an empty doc_ids when it is not specified

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -348,7 +348,7 @@ module CouchRest
         payload['target'] = other_db.root
       end
       payload['continuous'] = continuous
-      payload['doc_ids'] = options[:doc_ids] if options[:doc_ids]
+      payload.delete :doc_ids unless options[:doc_ids]
       CouchRest.post "#{@host}/_replicate", payload
     end
 


### PR DESCRIPTION
 def replicate(other_db, continuous, options)
      ...
      # Here you are copying the options, so you have payload[:doc_ids]
      payload = options
      ...
      # And if options[:doc_ids] is nil, payload still has the :doc_ids set to nil... it should be removed...
      payload['doc_ids'] = options[:doc_ids] if options[:doc_ids]

So I changed that line to:

```
  payload.delete :doc_ids unless options[:doc_ids]
```

(well, you can see it in the diff, but the explanation is worth it :-P)

Sorry, I don't know how to spec it (or why your current spec passes)
