### PR TITLE
Make sure we don't pass { doc_ids: null } when triggering replication

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -349,6 +349,7 @@ module CouchRest
       end
       payload['continuous'] = continuous
       payload['doc_ids'] = options[:doc_ids] if options[:doc_ids]
+      payload.delete :doc_ids unless payload[:doc_ids]
       CouchRest.post "#{@host}/_replicate", payload
     end
 


### PR DESCRIPTION
It looks like CouchDB used to tolerate sending the doc_ids parameter as null when starting a new replication. I'm not sure where the change occurred, but it's no longer so tolerant. With this change, all tests pass against 1.1.1a8d53b7d-git.

(There's a bigger refactor to be had here, I think: it's not clear to me how the handling of the 'options' parameter to CouchRest::Database#replicate is supposed to work. If I wouldn't be treading on anyone's toes, I'm happy to tackle this.)

Thanks

Stephen
