### PR TITLE
Fixed replication against new couchdb server (iris couch) bug caused by passing in null doc_ids

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -349,6 +349,7 @@ module CouchRest
       end
       payload['continuous'] = continuous
       payload['doc_ids'] = options[:doc_ids] if options[:doc_ids]
+      payload.delete :doc_ids unless payload[:doc_ids]
       CouchRest.post "#{@host}/_replicate", payload
     end
 


### PR DESCRIPTION
Fixed replication against new couchdb server (iris couch) bug caused by passing in null doc_ids
