### PR TITLE
Allow hashes with symbol keys for Database#save_doc

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -112,6 +112,7 @@ module CouchRest
     # accept the risk that a small proportion of updates could be lost due to a
     # crash."
     def save_doc(doc, bulk = false, batch = false)
+      doc = Document.new doc
       if doc['_attachments']
         doc['_attachments'] = encode_attachments(doc['_attachments'])
       end


### PR DESCRIPTION
Use Document in Database#save_doc to allow non-string hashes as arguments.

So you can write stuff as:

db.save_doc({
    _id: "bleh",
    whatever: "Is quite awesome",
    plus_one: 3
})

And have it accept _id properly.
