### PR TITLE
Use _doc suffix in examples for delete and save

### DIFF
--- a/examples/word_count/word_count.rb
+++ b/examples/word_count/word_count.rb
@@ -28,7 +28,7 @@ books.keys.each do |book|
     while line = file.gets
       lines << line
       if lines.length > 10
-        db.save({
+        db.save_doc({
           :title => title,
           :chunk => chunk, 
           :text => lines.join('')

--- a/examples/word_count/word_count_views.rb
+++ b/examples/word_count/word_count_views.rb
@@ -16,9 +16,9 @@ word_count = {
   }'
 }
 
-db.delete db.get("_design/word_count") rescue nil
+db.delete_doc db.get("_design/word_count") rescue nil
 
-db.save({
+db.save_doc({
   "_id" => "_design/word_count",
   :views => {
     :words => word_count


### PR DESCRIPTION
Hello,

While trying to reproduce something that is done in an example, I realized that `delete`  and `save` are used instead of `delete_doc` and `save_doc` in the examples. Maybe it is the legacy of on old version of database object. I don't know but here is a commit to fix that issue in my `fix-examples` branch.

Cheers,
mig 
