### PR TITLE
Bugfix: Database#view should not modify the params

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -243,6 +243,7 @@ module CouchRest
     # Query a CouchDB view as defined by a <tt>_design</tt> document. Accepts
     # paramaters as described in http://wiki.apache.org/couchdb/HttpViewApi
     def view(name, params = {}, payload = {}, &block)
+      params = params.dup
       payload['keys'] = params.delete(:keys) if params[:keys]
       # Try recognising the name, otherwise assume already prepared
       view_path = name_to_view_path(name)

--- a/spec/couchrest/database_spec.rb
+++ b/spec/couchrest/database_spec.rb
@@ -137,6 +137,12 @@ describe CouchRest::Database do
       rs = @db.view('first/test', :keys => ["another", "wild"])
       rs['rows'].length.should == 2
     end
+    it "should not modify given params" do
+      original_params = {:keys => ["another", "wild"]}
+      params = original_params.dup
+      rs = @db.view('first/test', params)
+      params.should == original_params
+    end
     it "should accept a block" do
       rows = []
       rs = @db.view('first/test', :include_docs => true) do |row|


### PR DESCRIPTION
Currently Database#view(params) manipulates the given params hash by deleting :keys.
Your average rubyists generally expects methods not to modify a hash given as a named parameter.
It cost me some time debugging, so I fixed it. Test enclosed.
