### PR TITLE
Add support for atomic bulk save requests

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -163,7 +163,7 @@ module CouchRest
     # missing ids, supply one from the uuid cache.
     #
     # If called with no arguments, bulk saves the cache of documents to be bulk saved.
-    def bulk_save(docs = nil, use_uuids = true)
+    def bulk_save(docs = nil, use_uuids = true, all_or_nothing = false)
       if docs.nil?
         docs = @bulk_save_cache
         @bulk_save_cache = []
@@ -176,7 +176,11 @@ module CouchRest
           doc['_id'] = nextid if nextid
         end
       end
-      CouchRest.post "#{@root}/_bulk_docs", {:docs => docs}
+      request_body = {:docs => docs}
+      if all_or_nothing
+        request_body[:all_or_nothing] = true
+      end
+      CouchRest.post "#{@root}/_bulk_docs", request_body
     end
     alias :bulk_delete :bulk_save
 

--- a/spec/couchrest/database_spec.rb
+++ b/spec/couchrest/database_spec.rb
@@ -246,6 +246,13 @@ describe CouchRest::Database do
       @db.bulk_save
       @db.get("bulk_cache_1")["val"].should == "test"
     end
+    
+    it "should make an atomic write when all_or_nothing is set" do
+      docs = [{"_id" => "oneB", "wild" => "and random"}, {"_id" => "twoB", "mild" => "yet local"}]
+      CouchRest.should_receive(:post).with("#{COUCHHOST}/couchrest-test/_bulk_docs", {:all_or_nothing => true, :docs => docs})
+      
+      @db.bulk_save(docs, false, true)
+    end
 
     it "should raise an error that is useful for recovery" do
       @r = @db.save_doc({"_id" => "taken", "field" => "stuff"})


### PR DESCRIPTION
hey,

I added atomic bulk saves to couchrest using the all_or_nothing parameter. for more info see http://wiki.apache.org/couchdb/HTTP_Bulk_Document_API#line-95

greets.
