### PR TITLE
Change Streamer to use a temp file for passing data to curl

### DIFF
--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_dependency(%q<multi_json>, ["~> 1.0.0"])
   s.add_development_dependency(%q<json>, ["~> 1.5.1"])
   s.add_development_dependency(%q<rspec>, "~> 2.6.0")
+  s.add_development_dependency(%q<rake>)
 end

--- a/lib/couchrest/helper/streamer.rb
+++ b/lib/couchrest/helper/streamer.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 module CouchRest
   class Streamer
 
@@ -16,7 +18,11 @@ module CouchRest
     end
 
     def post(url, params = {}, &block)
-      open_pipe("curl #{default_curl_opts} -d \"#{escape_quotes(MultiJson.encode(params))}\" \"#{url}\"", &block)
+      Tempfile.open('couchrest-post') do |tmp_file|
+        tmp_file.write(MultiJson.encode(params))
+        tmp_file.close
+        open_pipe("curl #{default_curl_opts} -d @#{tmp_file.path} \"#{url}\"", &block)
+      end
     end
 
     protected

--- a/spec/couchrest/helpers/streamer_spec.rb
+++ b/spec/couchrest/helpers/streamer_spec.rb
@@ -120,6 +120,7 @@ describe CouchRest::Streamer do
     @streamer.get("#{@db.root}/_design/first/_view/test?limit=2") do |row|
       ids << row['id']
     end
+    ids.should have(2).items
     count = 0
     @streamer.post("#{@db.root}/_all_docs?include_docs=true", :keys => ids) do |row|
       count += 1


### PR DESCRIPTION
In the current implementation, if you have a lot of data that you are going to post to couch using the streamer, you can overflow the command line. This changes the implementation to use a tempfile.