### PR TITLE
Update multi_json dependency so we can use any 1.x version.

### DIFF
--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<rest-client>, ["~> 1.6.1"])
   s.add_dependency(%q<mime-types>, ["~> 1.15"])
-  s.add_dependency(%q<multi_json>, ["~> 1.0.0"])
+  s.add_dependency(%q<multi_json>, ["~> 1.0"])
   s.add_development_dependency(%q<json>, ["~> 1.5.1"])
   s.add_development_dependency(%q<rspec>, "~> 2.6.0")
 end


### PR DESCRIPTION
The couchrest gem uses a stricter multi_json dependency than most other libraries.  It only allows 1.0.x versions, while other users of multi_json (activesupport, execjs, uglifier, sprockets, etc.) allow any 1.x version.

This causes the following gem conflict when multiple versions of multi_json are installed:
Unable to activate couchrest-1.1.2, because multi_json-1.2.0 conflicts with multi_json (~> 1.0.0)

This is also causing this problem:
https://github.com/negativecode/vines/issues/11

Can we update the dependency on multi_json so it plays nicely with other gems?
