### PR TITLE
Remove deprecation. All stale to be removed from request.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'bundler'
 require 'rspec/core/rake_task'
-require "rake/rdoctask"
+require "rdoc/task"
 
 Bundler::GemHelper.install_tasks
 

--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<rest-client>, ["~> 1.6.1"])
   s.add_dependency(%q<mime-types>, ["~> 1.15"])
-  s.add_dependency(%q<multi_json>, ["~> 1.0.0"])
+  s.add_dependency(%q<multi_json>, ["~> 1.0"])
   s.add_development_dependency(%q<json>, ["~> 1.5.1"])
   s.add_development_dependency(%q<rspec>, "~> 2.6.0")
 end

--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<rest-client>, ["~> 1.6.1"])
   s.add_dependency(%q<mime-types>, ["~> 1.15"])
-  s.add_dependency(%q<multi_json>, ["~> 1.0"])
+  s.add_dependency(%q<multi_json>, ["~> 1.8"])
   s.add_development_dependency(%q<json>, ["~> 1.5.1"])
   s.add_development_dependency(%q<rspec>, "~> 2.6.0")
 end

--- a/lib/couchrest.rb
+++ b/lib/couchrest.rb
@@ -110,6 +110,9 @@ module CouchRest
 
     def paramify_url url, params = {}
       if params && !params.empty?
+        # Allow a caller to completely remove param from
+        # query (e.g., remove :stale) by setting nil
+        params.reject!{|k,v| v.nil? }
         query = params.collect do |k,v|
           v = MultiJson.encode(v) if %w{key startkey endkey}.include?(k.to_s)
           "#{k}=#{CGI.escape(v.to_s)}"

--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -385,8 +385,11 @@ module CouchRest
 
     def encode_attachments(attachments)
       attachments.each do |k,v|
-        next if v['stub']
+        next if v['stub'] || (v.respond_to?(:encoded?) && v.encoded?)
         v['data'] = base64(v['data'])
+        def v.encoded?
+          true
+        end
       end
       attachments
     end

--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -112,7 +112,6 @@ module CouchRest
     # accept the risk that a small proportion of updates could be lost due to a
     # crash."
     def save_doc(doc, bulk = false, batch = false)
-      doc = Document.new doc
       if doc['_attachments']
         doc['_attachments'] = encode_attachments(doc['_attachments'])
       end
@@ -123,7 +122,9 @@ module CouchRest
       elsif !bulk && @bulk_save_cache.length > 0
         bulk_save
       end
-      result = if doc['_id']
+      doc_id = doc['_id'] || doc[:_id] || doc[:id] || doc["id"]
+      result = if doc_id
+        doc['_id'] = doc_id
         slug = escape_docid(doc['_id'])
         begin
           uri = "#{@root}/#{slug}"

--- a/lib/couchrest/design.rb
+++ b/lib/couchrest/design.rb
@@ -42,6 +42,17 @@ JAVASCRIPT
     # Dispatches to any named view in a specific database
     def view_on db, view_name, query = {}, &block
       raise ArgumentError, "View query options must be set as symbols!" if query.keys.find{|k| k.is_a?(String)}
+      if query.has_key?(:key) && query[:key].nil?
+        if defined?(Airbrake)
+          begin
+            raise ArgumentError, "key cannot be nil"
+          rescue => e
+            Airbrake.notify(e,{:parameters => {:db => db.name, :view => view_name, :query => query}})
+          end
+        end
+        return {"rows" => []}
+      end
+
       view_name = view_name.to_s
       view_slug = "#{name}/#{view_name}"
       # Set the default query options


### PR DESCRIPTION
One little fix to a deprecation warning in 1.9.3. Still works in 1.9.2.

Another subtle fix to filter out nil arguments in requests. Many of our views set {:stale => :update_after}. CouchDB does not define any other option for stale, so we cannot simple override it with {:stale => :update_immediately}.

The ORM needs to provide a way to remove a value from the views defaults. If you pass in nil for any value it will be sifted out before constructing the query so this is useful for more than just overriding "stale".