### PR TITLE
Synchronize access to Server#next_uuid

### DIFF
--- a/lib/couchrest/server.rb
+++ b/lib/couchrest/server.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module CouchRest
   class Server
     attr_accessor :uri, :uuid_batch_count, :available_databases
@@ -80,12 +82,9 @@ module CouchRest
     end
 
     # Retrive an unused UUID from CouchDB. Server instances manage caching a list of unused UUIDs.
+    # The count argument is deprecated and has no effect anymore.
     def next_uuid(count = @uuid_batch_count)
-      @uuids ||= []
-      if @uuids.empty?
-        @uuids = CouchRest.get("#{@uri}/_uuids?count=#{count}")["uuids"]
-      end
-      @uuids.pop
+      SecureRandom.uuid
     end
 
   end

--- a/spec/couchrest/server_spec.rb
+++ b/spec/couchrest/server_spec.rb
@@ -30,6 +30,17 @@ describe CouchRest::Server do
       @couch.default_database = 'cr-server-test-default-db'
       @couch.available_database?(:default).should be_true
     end
+
+    it "should synchronize access to #next_uuid" do
+      uuids1 = []
+      uuids2 = []
+      Thread.new @couch do |server|
+        500.times { uuids1 << server.next_uuid }
+      end
+      500.times { uuids2 << @couch.next_uuid }
+      sleep 0.001 until uuids1.size == 500
+      (uuids1 + uuids2).uniq.size.should be_equal (uuids1 + uuids2).size
+    end
   end
   
 end


### PR DESCRIPTION
In threaded environments, multiple threads might be requesting a UUID at the same time.

This causes problems on JRuby where Array objects are not thread safe and calling
# pop was returning the same value to multiple threads!
