### PR TITLE
Prevent the first change in a continuous _changes feed from being stripped by open_pipe

### DIFF
--- a/lib/couchrest/helper/streamer.rb
+++ b/lib/couchrest/helper/streamer.rb
@@ -29,7 +29,8 @@ module CouchRest
       first = nil
       prev = nil
       IO.popen(cmd) do |f|
-        first = f.gets # discard header
+        # Discard header, unless it's a continuous changes feed
+        first = f.gets unless cmd =~ /\/_changes\?(.+&)?feed=continuous(?=[&$])/
         while line = f.gets 
           row = parse_line(line)
           block.call row unless row.nil? # last line "}]" discarded


### PR DESCRIPTION
I noticed the current open_pipe command will not emit the first change from a changes feed if it's continuous.

This happens because the continuous feed has a 'one revision per line' layout, rather than the usual, so assuming the first line of the response is a header leads to losing a line of your changes.

Not quite sure how to write a test for this at the moment - sorry!