### PR TITLE
Allow json object decoding on get requests

### DIFF
--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<rest-client>, ["~> 1.6.1"])
   s.add_dependency(%q<mime-types>, ["~> 1.15"])
-  s.add_dependency(%q<multi_json>, ["~> 1.0"])
-  s.add_development_dependency(%q<json>, ["~> 1.5.1"])
+  s.add_dependency(%q<multi_json>, ["~> 1.6.0"])
+  s.add_development_dependency(%q<json>, ["~> 1.5.5"])
   s.add_development_dependency(%q<rspec>, "~> 2.6.0")
 end


### PR DESCRIPTION
This Pull Request refers to https://github.com/couchrest/couchrest/issues/92

Since http://seclists.org/oss-sec/2013/q1/283 the json gem doesn't allow object decoding by default. Gems, such as CouchPotato, are based on this mechanism. This commit allows to decide on every GET request to turn object decoding back on.

``` ruby
class TestObject
  def self.json_create(args)
    new
  end
end

# Given you have the following json document stored in your couchdb
# {'_id' => "42", JSON.create_id => 'TestObject'}

CouchRest.new('http://mydburl').database('test').get("42", :decode_object => true).class

# => TestObject

```

It also updates gem dependencies to safe gem versions.
