### PR TITLE
Fix error message to use correct params

### DIFF
--- a/lib/couchrest/rest_api.rb
+++ b/lib/couchrest/rest_api.rb
@@ -94,7 +94,7 @@ module CouchRest
         parse_response(RestClient::Request.execute(request), parser)
       rescue Exception => e
         if $DEBUG
-          raise "Error while sending a #{method.to_s.upcase} request #{uri}\noptions: #{opts.inspect}\n#{e}"
+          raise "Error while sending a #{method.to_s.upcase} request #{url}\noptions: #{options.inspect}\n#{e}"
         else
           raise e
         end


### PR DESCRIPTION
The string interpolation at the moment uses non-existant params