### PR TITLE
Add global configuration option to decode JSON objects

### DIFF
--- a/lib/couchrest.rb
+++ b/lib/couchrest.rb
@@ -43,7 +43,7 @@ module CouchRest
   # the get, post, put, delete and copy
   CouchRest.extend(::CouchRest::RestAPI)
 
-  # The CouchRest module methods handle the basic JSON serialization 
+  # The CouchRest module methods handle the basic JSON serialization
   # and deserialization, as well as query parameters. The module also includes
   # some helpers for tasks like instantiating a new Database or Server instance.
   class << self
@@ -117,6 +117,18 @@ module CouchRest
         url = "#{url}?#{query}"
       end
       url
+    end
+
+    @@decode_json_objects = false
+
+    def decode_json_objects=(value)
+      @@decode_json_objects = value
+    end
+
+    # When set to true, CouchRest.get tries to decode the JSON returned
+    # from CouchDB into a Ruby object. Default: false.
+    def decode_json_objects
+      @@decode_json_objects
     end
   end # class << self
 end

--- a/lib/couchrest/rest_api.rb
+++ b/lib/couchrest/rest_api.rb
@@ -30,7 +30,7 @@ module CouchRest
   #
   # Any other remaining options will be sent to the MultiJSON backend except for the :raw option.
   #
-  # When :raw is true in PUT and POST requests, no attempt will be made to convert the document payload to JSON. This is 
+  # When :raw is true in PUT and POST requests, no attempt will be made to convert the document payload to JSON. This is
   # not normally necessary as IO and Tempfile objects will not be parsed anyway. The result of the request will
   # *always* be parsed.
   #
@@ -84,7 +84,7 @@ module CouchRest
 
     private
 
-    # Perform the RestClient request by removing the parse specific options, ensuring the 
+    # Perform the RestClient request by removing the parse specific options, ensuring the
     # payload is prepared, and sending the request ready to parse the response.
     def execute(url, method, options = {}, payload = nil)
       request, parser = prepare_and_split_options(url, method, options)
@@ -131,7 +131,7 @@ module CouchRest
       [request, parser]
     end
 
-    # Check if the provided doc is nil or special IO device or temp file. If not, 
+    # Check if the provided doc is nil or special IO device or temp file. If not,
     # encode it into a string.
     #
     # The options supported are:
@@ -147,6 +147,7 @@ module CouchRest
 
     # Parse the response provided.
     def parse_response(result, opts = {})
+      opts = opts.update(:create_additions => true) if decode_json_objects
       (opts.delete(:raw) || opts.delete(:head)) ? result : MultiJson.decode(result, opts.update(:max_nesting => false))
     end
 

--- a/spec/couchrest/rest_api_spec.rb
+++ b/spec/couchrest/rest_api_spec.rb
@@ -98,6 +98,27 @@ describe CouchRest::RestAPI do
         expect { CouchRest.get('foo') }.to raise_error(RestClient::Exception)
       end
 
+      context 'when decode_json_objects is true' do
+        class TestObject
+          def self.json_create(args)
+            new
+          end
+        end
+
+        before(:each) do
+          CouchRest.decode_json_objects = true
+        end
+
+        after(:each) do
+          CouchRest.decode_json_objects = false
+        end
+
+        it 'should return the response as a Ruby object' do
+          CouchRest.put "#{COUCHHOST}/#{TESTDB}/test", JSON.create_id => TestObject.to_s
+
+          CouchRest.get("#{COUCHHOST}/#{TESTDB}/test").class.should eql(TestObject)
+        end
+      end
     end
 
     describe :post do


### PR DESCRIPTION
Following up on https://github.com/couchrest/couchrest/pull/93 this adds a global option `decode_json_objects`.
