### PR TITLE
Streamer: correctly handle continuous feeds

### DIFF
--- a/lib/couchrest/helper/streamer.rb
+++ b/lib/couchrest/helper/streamer.rb
@@ -34,9 +34,9 @@ module CouchRest
           first = line  # save header
         else
           row = parse_line(line)
-          if row.has_key?("rows") || row.has_key?("results")
+          if row && (row.has_key?("rows") || row.has_key?("results"))
             first = line  # this is a view or _changes result
-          else
+          elsif row
             block.call row  # no header; yield row to block
           end
         end

--- a/spec/couchrest/helpers/streamer_spec.rb
+++ b/spec/couchrest/helpers/streamer_spec.rb
@@ -136,7 +136,9 @@ describe CouchRest::Streamer do
       class F
         def initialize
           @lines = [
+            '',            # there may be empty lines due to heartbeat
             '{"foo": 1}',  # line does NOT begin list, so we should get it
+            '',
             '{"foo": 2}',
           ]
         end


### PR DESCRIPTION
When querying _changes API with feed=continuous, the first output
row is always discarded.  Implement the following heuristic to
correctly deal with continuous feeds:

1) If the line ends with "[", it is a header.  Do not yield it.
2) Parse the line.  If the row has a "rows" or "results" key, it
   is a complete header (either from view or changes API).  Do not
   yield it.
3) There is no header.  Yield the row.

Return `nil` if the continuous feed ends since there is no header.

Step 2) contains some CouchDB API-specific knowledge; this is
unfortunate.  One approach to remove this knowledge would be to
parameterise the `get` and `post` methods with a key to look for
to determine if the first line is a complete header (i.e. no result
rows), or if it is a result row (i.e. no header, as in a continuous
feed).  However, this commit sacrifices such purity to keep the
change small and the risk low.

Spec for continuous feed behaviour is included.
