### PR TITLE
Add license in gemspec

### DIFF
--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -3,6 +3,7 @@
 Gem::Specification.new do |s|
   s.name = %q{couchrest}
   s.version = `cat VERSION`.strip
+  s.license = "Apache License 2.0"
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1") if s.respond_to? :required_rubygems_version=
   s.authors = ["J. Chris Anderson", "Matt Aimonetti", "Marcos Tapajos", "Will Leinweber", "Sam Lown"]


### PR DESCRIPTION
So that tools like LicenseFinder can check licenses across gems better.

See https://github.com/rubygems/rubygems.org/issues/363 too
