### PR TITLE
Update couchrest.gemspec

### DIFF
--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -27,11 +27,11 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Lean and RESTful interface to CouchDB.}
 
-  s.add_dependency(%q<rest-client>, ["~> 1.6.1"])
-  s.add_dependency(%q<mime-types>, ["~> 1.15"])
-  s.add_dependency(%q<multi_json>, ["~> 1.0"])
+  s.add_dependency(%q<rest-client>, [">= 1.6.1"])
+  s.add_dependency(%q<mime-types>, [">= 1.15"])
+  s.add_dependency(%q<multi_json>, [">= 1.0"])
   s.add_development_dependency(%q<json>, [">= 1.7.0"])
-  s.add_development_dependency(%q<rspec>, "~> 2.6.0")
+  s.add_development_dependency(%q<rspec>, ">= 2.6.0")
   s.add_development_dependency(%q<rake>)
-  s.add_development_dependency(%q<multi_json>, "~> 1.7") # needed for json decode json objects
+  s.add_development_dependency(%q<multi_json>, ">= 1.7") # needed for json decode json objects
 end


### PR DESCRIPTION
allow newer gems, especially mime-types which has new caching features in 2.1 but was locked to 1.x. The current locks actually cause bundle to go back to couchrest 1.0 which had more lenient dependencies