### PR TITLE
Preserve the first change in continuous feeds

### DIFF
--- a/lib/couchrest/helper/streamer.rb
+++ b/lib/couchrest/helper/streamer.rb
@@ -29,10 +29,13 @@ module CouchRest
       first = nil
       prev = nil
       IO.popen(cmd) do |f|
-        first = f.gets # discard header
-        while line = f.gets 
+        while line = f.gets
           row = parse_line(line)
-          block.call row unless row.nil? # last line "}]" discarded
+          if row.nil?
+            first ||= line # save the header for later if we can't parse it.
+          else
+            block.call row
+          end
           prev = line
         end
       end

--- a/spec/couchrest/database_spec.rb
+++ b/spec/couchrest/database_spec.rb
@@ -189,6 +189,18 @@ describe CouchRest::Database do
       c['results'].length.should eql(3)
     end
 
+    it "should include all changes in continuous feed" do
+      changes = []
+      begin
+        c = @db.changes("feed" => "continuous", "since" => "0") do |change|
+          changes << change
+          raise RuntimeError.new # escape from infinite loop
+        end
+      rescue RuntimeError
+      end
+      changes.first["seq"].should eql(1)
+    end
+
     it "should provide id of last document" do
       c = @db.changes
       doc = @db.get(c['results'].last['id'])


### PR DESCRIPTION
solves #91

Couch will send valid json hashes from the first line of continuous changes feeds on. So we may not drop that line.

The regexp in parse_line will already catch the headers. So we can use it to test if the first line was only a header or containing a change.

This implementation will store the first line that does not get parsed in first. This might not always be a header but i can't think of any couch document that would cause this to misbehave. In the worst case the first non parsing line and the last line will be combined and parsed again.