### PR TITLE
fix uri/url typo in rest_api execute

### DIFF
--- a/lib/couchrest/rest_api.rb
+++ b/lib/couchrest/rest_api.rb
@@ -94,7 +94,7 @@ module CouchRest
         parse_response(RestClient::Request.execute(request), parser)
       rescue Exception => e
         if $DEBUG
-          raise "Error while sending a #{method.to_s.upcase} request #{uri}\noptions: #{opts.inspect}\n#{e}"
+          raise "Error while sending a #{method.to_s.upcase} request #{url}\noptions: #{opts.inspect}\n#{e}"
         else
           raise e
         end


### PR DESCRIPTION
If $DEBUG is true, couchrest won't work because error message refers to non-existant uri variable. replaced with url.
