### PR TITLE
Update rest-client dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,5 @@ rvm:
   - 2.0.0
   - 1.9.3
   - 1.9.2
-  - 1.8.7
-  - ree-1.8.7
   - jruby
 services: couchdb

--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Lean and RESTful interface to CouchDB.}
 
-  s.add_dependency(%q<rest-client>, ["~> 1.6.1"])
+  s.add_dependency(%q<rest-client>, ["~> 1.8.0"])
   s.add_dependency(%q<mime-types>, ["~> 1.15"])
   s.add_dependency(%q<multi_json>, ["~> 1.0"])
   s.add_development_dependency(%q<json>, [">= 1.7.0"])


### PR DESCRIPTION
As there are known security issues prior to `1.8.0`, see
- https://github.com/rest-client/rest-client/issues/349 and
- https://github.com/rest-client/rest-client/issues/369

This also implies dropping support for `ruby-1.8.7`, since `rest-client` no longer supports this as well.