### PR TITLE
Return headers content for HEAD requests

### DIFF
--- a/lib/couchrest/connection.rb
+++ b/lib/couchrest/connection.rb
@@ -90,7 +90,7 @@ module CouchRest
 
     # Send a HEAD request.
     def head(path, options = {})
-      options = options.merge(:raw => true) # No parsing!
+      options = options.merge(:head => true) # No parsing!
       execute('HEAD', path, options)
     end
 
@@ -164,7 +164,7 @@ module CouchRest
       else
         response = send_request(req)
         handle_response_code(response)
-        parse_body(response.body, options)
+        parse_response(response, options)
       end
     end
 
@@ -175,6 +175,14 @@ module CouchRest
 
     def handle_response_code(response)
       raise_response_error(response) unless SUCCESS_RESPONSE_CODES.include?(response.status)
+    end
+
+    def parse_response(response, opts)
+      if opts[:head]
+        opts[:raw] ? response.http_header.dump : response.headers
+      else
+        parse_body(response.body, opts)
+      end
     end
 
     def parse_body(body, opts)

--- a/spec/couchrest/connection_spec.rb
+++ b/spec/couchrest/connection_spec.rb
@@ -417,6 +417,26 @@ describe CouchRest::Connection do
           .to_return(:body => "")
         expect { mock_conn.head('db/test-head') }.to_not raise_error
       end
+      it "should returns headers hash" do
+        response_headers = { "Etag" => "document-version-number" }
+        stub_request(:head, "http://mock/db/test-head")
+        .to_return(
+            :body => "",
+            :headers => response_headers
+        )
+        expect(mock_conn.head('db/test-head')).to eq(response_headers)
+      end
+
+      it "should returns raw headers if opts[:raw] true" do
+        response_headers = { "Etag" => "document-version-number" }
+        stub_request(:head, "http://mock/db/test-head")
+        .to_return(
+            :body => "",
+            :headers => response_headers
+        )
+        expect(mock_conn.head('db/test-head', {raw: true})).to include("Etag: document-version-number" )
+      end
+
       it "should handle head request when document missing" do
         stub_request(:head, "http://mock/db/test-missing-head")
           .to_return(:status => 404)


### PR DESCRIPTION
When we send a HEAD requests, we need to access headers content to obtain document version from Etag header. 
