### PR TITLE
Pass connection options

### DIFF
--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec", "~> 2.14.1")
   s.add_development_dependency("rake")
   s.add_development_dependency("webmock")
-  s.add_development_dependency("mime-types", "2.6.2") # Avoid Errors with 3.0 series
 end

--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec", "~> 2.14.1")
   s.add_development_dependency("rake")
   s.add_development_dependency("webmock")
+  s.add_development_dependency("mime-types", "2.6.2") # Avoid Errors with 3.0 series
 end

--- a/lib/couchrest/server.rb
+++ b/lib/couchrest/server.rb
@@ -3,7 +3,7 @@ module CouchRest
 
     # URI object of the link to the server we're using.
     attr_reader :uri
-    
+
     # Number of UUIDs to fetch from the server when preparing to save new
     # documents. Set to 1000 by default.
     attr_reader :uuid_batch_count
@@ -12,15 +12,20 @@ module CouchRest
     # saving new documents. See also #next_uuid.
     attr_reader :uuids
 
-    def initialize(server = 'http://127.0.0.1:5984', uuid_batch_count = 1000)
+    # Accessor for the current connection options which will be passed to all
+    # created connections.
+    attr_reader :connection_options
+
+    def initialize(server = 'http://127.0.0.1:5984', uuid_batch_count = 1000, connection_options = {})
       @uri = prepare_uri(server).freeze
       @uuid_batch_count = uuid_batch_count
+      @connection_options = connection_options
     end
 
     # Lazy load the connection for the current thread
     def connection
       conns = (Thread.current['couchrest.connections'] ||= {})
-      conns[uri.to_s] ||= Connection.new(uri)
+      conns[uri.to_s] ||= Connection.new(uri, @connection_options)
     end
 
     # Lists all databases on the server

--- a/lib/couchrest/server.rb
+++ b/lib/couchrest/server.rb
@@ -16,10 +16,10 @@ module CouchRest
     # created connections.
     attr_reader :connection_options
 
-    def initialize(server = 'http://127.0.0.1:5984', uuid_batch_count = 1000, connection_options = {})
+    def initialize(server = 'http://127.0.0.1:5984', options = {})
       @uri = prepare_uri(server).freeze
-      @uuid_batch_count = uuid_batch_count
-      @connection_options = connection_options
+      @uuid_batch_count = options.delete(:uuid_batch_count) || 1000
+      @connection_options = options
     end
 
     # Lazy load the connection for the current thread

--- a/spec/couchrest/couchrest_spec.rb
+++ b/spec/couchrest/couchrest_spec.rb
@@ -6,7 +6,7 @@ describe CouchRest do
     @cr = CouchRest.new(COUCHHOST)
     begin
       @db = @cr.database(TESTDB)
-      @db.delete! rescue nil      
+      @db.delete! rescue nil
     end
   end
 
@@ -28,7 +28,7 @@ describe CouchRest do
     end
     it "should get info" do
       expect(@cr.info["couchdb"]).to eq "Welcome"
-      expect(@cr.info.class).to eq Hash   
+      expect(@cr.info.class).to eq Hash
     end
   end
 
@@ -129,7 +129,7 @@ describe CouchRest do
     #    end
     it "should not create the database automatically" do
       db = CouchRest.database "http://127.0.0.1:5984/couchrest-test"
-      expect(lambda{db.info}).to raise_error(CouchRest::NotFound)      
+      expect(lambda{db.info}).to raise_error(CouchRest::NotFound)
     end
   end
 

--- a/spec/couchrest/server_spec.rb
+++ b/spec/couchrest/server_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path("../../spec_helper", __FILE__)
 
 describe CouchRest::Server do
-  
+
   let :server do
     CouchRest::Server.new(COUCHHOST)
   end
@@ -11,6 +11,7 @@ describe CouchRest::Server do
   end
 
   describe "#initialize" do
+
     it "should prepare frozen URI object" do
       expect(server.uri).to be_a(URI)
       expect(server.uri).to be_frozen
@@ -21,6 +22,27 @@ describe CouchRest::Server do
       server = CouchRest::Server.new(COUCHHOST + "/some/path?q=1#fragment")
       expect(server.uri.to_s).to eql(COUCHHOST)
     end
+
+    it "should set the uuid_batch_count if provided" do
+      server = CouchRest::Server.new(COUCHHOST, :uuid_batch_count => 5000)
+      expect(server.uuid_batch_count).to eql(5000)
+    end
+
+    it "should not treat uuid_batch_count as a connection option" do
+      server = CouchRest::Server.new(COUCHHOST, :uuid_batch_count => 5000)
+      expect(server.connection_options).not_to include(:uuid_batch_count)
+    end
+
+    it "should set a default for uuid_batch_count" do
+      expect(server.uuid_batch_count).not_to eql(nil)
+      expect(server.uuid_batch_count).to be_a(Integer)
+    end
+
+    it "should store extra connection options" do
+      server = CouchRest::Server.new(COUCHHOST, :verify_ssl => true)
+      expect(server.connection_options[:verify_ssl]).to eql(true)
+    end
+
   end
 
   describe :connection do
@@ -82,8 +104,7 @@ describe CouchRest::Server do
   describe :restart do
     it "should send restart request" do
       # we really do not need to perform a proper restart!
-      stub_request(:post, "http://mock/_restart")
-        .to_return(:body => "{\"ok\":true}")
+      stub_request(:post, "http://mock/_restart").to_return(:body => "{\"ok\":true}")
       mock_server.restart!
     end
   end


### PR DESCRIPTION
Currently it is fairly difficult to create a CouchRest::Server which will use ssl client certificates, due to the fact that a different connection is created for each Thread and there is no way to pass the options to the CouchRest::Server so that every connection gets initialised with the same options.

This pull request changes the second parameter of the Server initialize method to an options hash, where :uuid_batch_count will be removed & used if it is included & all other parameters are passed to the initialize method of all CouchRest::Connections which are created.

I removed uuid_batch_count as a separate parameter as otherwise it must always be specified when specifying the connection options. If you're not okay with that then could we add a hash of connection options in addition (just means you will always have to specify the batch count if you want to specify connection option) or something else if you have a better suggestion?