### PR TITLE
Update the revisions when bulk saving

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -203,7 +203,7 @@ module CouchRest
         request_body[:all_or_nothing] = true
       end
       results = connection.post "#{path}/_bulk_docs", request_body
-      docs_by_id = Hash[docs.map { |doc| [doc['_id'], doc] }]
+      docs_by_id = Hash[docs.map { |doc| [doc['_id'], doc] }] unless docs.nil?
       results.each { |r| docs_by_id[r['id']]['_rev'] = r['rev'] if r['ok'] } unless results.nil?
       results
     end

--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -202,7 +202,12 @@ module CouchRest
       if opts[:all_or_nothing]
         request_body[:all_or_nothing] = true
       end
-      connection.post "#{path}/_bulk_docs", request_body
+      results = connection.post "#{path}/_bulk_docs", request_body
+      docs_by_id = Hash[docs.map { |doc| [doc['_id'], doc] }]
+      results.each do |r|
+        docs_by_id[r['id']]['_rev'] = r['rev'] if r['ok']
+      end
+      results
     end
     alias :bulk_delete :bulk_save
 

--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -204,9 +204,7 @@ module CouchRest
       end
       results = connection.post "#{path}/_bulk_docs", request_body
       docs_by_id = Hash[docs.map { |doc| [doc['_id'], doc] }]
-      results.each do |r|
-        docs_by_id[r['id']]['_rev'] = r['rev'] if r['ok']
-      end
+      results.each { |r| docs_by_id[r['id']]['_rev'] = r['rev'] if r['ok'] } unless results.nil?
       results
     end
     alias :bulk_delete :bulk_save

--- a/spec/couchrest/document_spec.rb
+++ b/spec/couchrest/document_spec.rb
@@ -239,6 +239,25 @@ describe CouchRest::Document do
       doc.database.bulk_save
       expect(doc.database.get(doc["_id"])["val"]).to eql doc["val"]
     end
+
+    it "should update the revisions of the saved documents" do
+      doc = CouchRest::Document.new({"_id" => "bulkdoc1", "val" => 3})
+      doc.database = @db
+      doc.save(true)
+      doc.database.bulk_save
+      expect(doc.database.get(doc["_id"])["_rev"]).to eql doc["_rev"]
+    end
+
+    it "should not update the revisions of documents that aren't saved successfully" do
+      doc1 = CouchRest::Document.new({"_id" => "bulkdoc", "val" => 3})
+      doc2 = CouchRest::Document.new({"_id" => "bulkdoc2", "val" => 3})
+      doc1.database = @db
+      doc2.database = @db
+      doc1.save(true)
+      doc2.save(true)
+      @db.bulk_save
+      expect(doc1["_rev"]).to be_nil
+    end
   end
 
   describe "getting from a database" do


### PR DESCRIPTION
The current `Database#bulk_save` method doesn't update the revisions of the documents from the response.