### PR TITLE
Prevent bulk save from requesting too many ids

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -192,9 +192,8 @@ module CouchRest
       end
       if opts[:use_uuids]
         ids, noids = docs.partition{|d|d['_id']}
-        uuid_count = [noids.length, @server.uuid_batch_count].max
         noids.each do |doc|
-          nextid = server.next_uuid(uuid_count) rescue nil
+          nextid = server.next_uuid
           doc['_id'] = nextid if nextid
         end
       end

--- a/spec/couchrest/database_spec.rb
+++ b/spec/couchrest/database_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path("../../spec_helper", __FILE__)
 
 describe CouchRest::Database do
   before(:each) do
-    @cr = CouchRest.new(COUCHHOST)
+    @cr = CouchRest.new(COUCHHOST, { uuid_batch_count: 2 })
     @db = @cr.database(TESTDB)
     @db.delete! rescue CouchRest::NotFound
     @db = @cr.create_db(TESTDB) # rescue nil
@@ -265,6 +265,13 @@ describe CouchRest::Database do
 
       expect(@db.connection).to receive(:post).with("/couchrest-test/_bulk_docs", {:docs => id_docs})
       
+      @db.bulk_save(docs)
+    end
+
+    it "should not request more uuids than the server's uuid limit" do
+      docs = [{'key' => 'value'}, {'key' => 'value'}, {'key' => 'value'}, {'key' => 'value'}, {'key' => 'value'}]
+
+      expect(@db.connection).to receive(:get).with("_uuids?count=2").exactly(3).times.and_call_original
       @db.bulk_save(docs)
     end
 


### PR DESCRIPTION
The current implementation will request uuids for all the documents passed to `bulk_save`, even if this number exceeds the current value for `server.uuid_batch_count` (and can even exceed the server's **uuid** `max_count` and return 403). This leads to an issue where new documents won't get ids and causes an exception in the `bulk_save` method when passed an array with more documents than the `uuid_batch_count`.

I've also removed a silent rescue to try and provide a bit more information to the caller in the event of an exception in `next_uuid`.

I realise that there was probably a reason for the code I've deleted here and I'm interested to know what that is. Perhaps this bug fix requires a bit more discussion?
