### PR TITLE
Allow update_doc to upsert instead of raising 

### DIFF
--- a/lib/couchrest/database.rb
+++ b/lib/couchrest/database.rb
@@ -249,6 +249,7 @@ module CouchRest
 
       until resp['ok'] or update_limit <= 0
         doc = self.get(doc_id, params)
+        doc = { '_id' => doc_id } if doc.nil?
         yield doc
         begin
           resp = self.save_doc doc

--- a/spec/couchrest/database_spec.rb
+++ b/spec/couchrest/database_spec.rb
@@ -657,6 +657,14 @@ describe CouchRest::Database do
       end
       expect(@db.get(@id)['upvotes']).to eq 11
     end
+    it "should upsert a missing id" do
+      new_id = 'new_id'
+      @db.update_doc new_id do |doc|
+        doc['status'] = 'new'
+      end
+      expect(@db.get(new_id)['status']).to eq 'new'
+    end
+    
     it "should fail if update_limit is reached" do
       expect do
         @db.update_doc @id do |doc|


### PR DESCRIPTION
undefined method []= for nil:NilClass
Fixes #127 