### PR TITLE
Include the response body in exception messages

### DIFF
--- a/lib/couchrest/exceptions.rb
+++ b/lib/couchrest/exceptions.rb
@@ -81,7 +81,7 @@ module CouchRest
   # The request failed with an error code not managed by the code
   class RequestFailed < Exception
     def message
-      "HTTP status code #{http_code}"
+      "HTTP #{http_code}: #{http_body}"
     end
 
     def to_s
@@ -95,7 +95,7 @@ module CouchRest
 
   STATUSES.each_pair do |code, message|
     klass = Class.new(RequestFailed) do
-      send(:define_method, :message) {"#{http_code ? "#{http_code} " : ''}#{message}"}
+      send(:define_method, :message) {"#{http_code ? "#{http_code} " : ''}#{message}#{http_body ? " #{http_body}" : ''}"}
     end
     klass_constant = const_set message.delete(' \-\''), klass
     Exceptions::EXCEPTIONS_MAP[code] = klass_constant

--- a/spec/couchrest/exceptions_spec.rb
+++ b/spec/couchrest/exceptions_spec.rb
@@ -24,7 +24,7 @@ end
 
 describe CouchRest::RequestFailed do
   before do
-    @response = double('HTTP Response', :status => 500)
+    @response = double('HTTP Response', :status => 500, :body => '{"error": "error_code", "reason": "Reason for error"}')
   end
 
   it "stores the http response on the exception" do
@@ -41,12 +41,15 @@ describe CouchRest::RequestFailed do
   end
 
   it "http_body convenience method for fetching the body (decoding when necessary)" do
-    expect(CouchRest::RequestFailed.new(@response).http_code).to eq 500
-    expect(CouchRest::RequestFailed.new(@response).message).to eq 'HTTP status code 500'
+    expect(CouchRest::RequestFailed.new(@response).http_body).to eq @response.body
   end
 
   it "shows the status code in the message" do
     expect(CouchRest::RequestFailed.new(@response).to_s).to match(/500/)
+  end
+
+  it "includes the response body in the message" do
+    expect(CouchRest::RequestFailed.new(@response).message).to match(/#{@response.body}/)
   end
 end
 


### PR DESCRIPTION
When couchdb returns an error response, the body often (always?) is JSON that includes an `error` and `reason`, for example:

```
```